### PR TITLE
Allow extra fields in sentreports.log

### DIFF
--- a/gtimesheet/tracker.py
+++ b/gtimesheet/tracker.py
@@ -121,7 +121,7 @@ def read_sent_reports(f):
     for line in f:
         line = line.strip()
         if line:
-            created, report, date = line.strip().split(',')
+            created, report, date = line.strip().split(',')[:3]
             reports.add(date)
     return reports
 


### PR DESCRIPTION
I want to change gtimelog to write to this file natively, and I want it to also record the destination email.

Because I'm often sending test reports to myself, and I'd like to distinguish those from real reports aferwards.
